### PR TITLE
Enable epoch-based checkpoint naming

### DIFF
--- a/quickstart/scripts/train_ddp_i2v.sh
+++ b/quickstart/scripts/train_ddp_i2v.sh
@@ -47,7 +47,7 @@ SYSTEM_ARGS=(
 
 # Checkpointing Configuration
 CHECKPOINT_ARGS=(
-    --checkpointing_steps 200  # save checkpoint every x steps
+    --checkpoint_each_epoch true  # save checkpoint after each epoch
     --checkpointing_limit 2   # maximum number of checkpoints to keep, after which the oldest one is deleted
     # --resume_from_checkpoint "/absolute/path/to/checkpoint_dir"  # if you want to resume from a checkpoint
 )

--- a/src/cogkit/finetune/base/base_args.py
+++ b/src/cogkit/finetune/base/base_args.py
@@ -30,8 +30,9 @@ class BaseArgs(BaseModel):
     seed: int | None = None
     train_epochs: int
     train_steps: int | None = None
-    checkpointing_steps: int = 200
+    checkpointing_steps: int | None = 200
     checkpointing_limit: int = 10
+    checkpoint_each_epoch: bool = False
 
     batch_size: int
     gradient_accumulation_steps: int = 1
@@ -149,7 +150,10 @@ class BaseArgs(BaseModel):
         )
 
         # Checkpointing
-        parser.add_argument("--checkpointing_steps", type=int, default=200)
+        parser.add_argument("--checkpointing_steps", type=int, default=None)
+        parser.add_argument(
+            "--checkpoint_each_epoch", type=lambda x: x.lower() == "true", default=False
+        )
         parser.add_argument("--checkpointing_limit", type=int, default=10)
         parser.add_argument("--resume_from_checkpoint", type=str, default=None)
 


### PR DESCRIPTION
## Summary
- create a `--checkpoint_each_epoch` option and make `checkpointing_steps` optional
- name checkpoints `Checkpoint_EpochN` when using epoch-based saving
- update training loop to save checkpoints after each epoch when requested
- modify `train_ddp_i2v.sh` to enable epoch checkpointing by default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cogkit')*

------
https://chatgpt.com/codex/tasks/task_e_6866854ce7c0832ba976943be9d19e28