### PR TITLE
Fix checkpoint naming and epoch validation

### DIFF
--- a/quickstart/scripts/train_ddp_i2v.sh
+++ b/quickstart/scripts/train_ddp_i2v.sh
@@ -55,7 +55,7 @@ CHECKPOINT_ARGS=(
 # Validation Configuration
 VALIDATION_ARGS=(
     --do_validation false   # ["true", "false"]
-    --validation_steps 200  # should be multiple of checkpointing_steps
+    --validation_steps 200  # ignored when checkpoint_each_epoch is true
     --gen_fps 16
 )
 

--- a/src/cogkit/finetune/base/base_args.py
+++ b/src/cogkit/finetune/base/base_args.py
@@ -30,7 +30,7 @@ class BaseArgs(BaseModel):
     seed: int | None = None
     train_epochs: int
     train_steps: int | None = None
-    checkpointing_steps: int | None = 200
+    checkpointing_steps: int | None = None
     checkpointing_limit: int = 10
     checkpoint_each_epoch: bool = False
 
@@ -79,8 +79,12 @@ class BaseArgs(BaseModel):
     def validate_validation_steps(cls, v: int | None, info: ValidationInfo) -> int | None:
         values = info.data
         if values.get("do_validation"):
+            if values.get("checkpoint_each_epoch"):
+                return v
             if v is None:
-                raise ValueError("validation_steps must be specified when do_validation is True")
+                raise ValueError(
+                    "validation_steps must be specified when do_validation is True and checkpoint_each_epoch is False"
+                )
             if values.get("checkpointing_steps") and v % values["checkpointing_steps"] != 0:
                 raise ValueError("validation_steps must be a multiple of checkpointing_steps")
         return v

--- a/src/cogkit/finetune/base/base_trainer.py
+++ b/src/cogkit/finetune/base/base_trainer.py
@@ -387,6 +387,8 @@ class BaseTrainer(ABC):
                     # Maybe run validation
                     should_run_validation = (
                         self.args.do_validation
+                        and not self.args.checkpoint_each_epoch
+                        and self.args.validation_steps is not None
                         and global_step % self.args.validation_steps == 0
                         and accelerator.sync_gradients
                     )
@@ -556,7 +558,7 @@ class BaseTrainer(ABC):
         output_dir = Path(self.args.output_dir)
         logger = self.logger
 
-        prefix = "Checkpoint_Epoch" if epoch is not None else "checkpoint"
+        prefix = "Checkpoint_Epoch-" if epoch is not None else "checkpoint"
         if checkpointing_limit is not None:
             checkpoints = find_files(output_dir, prefix=prefix)
 
@@ -569,7 +571,7 @@ class BaseTrainer(ABC):
 
         if epoch is not None:
             logger.info(f"Checkpointing at epoch {epoch}")
-            save_path = output_dir / f"Checkpoint_Epoch{epoch}"
+            save_path = output_dir / f"Checkpoint_Epoch-{epoch}"
         else:
             logger.info(f"Checkpointing at step {global_step}")
             save_path = output_dir / f"checkpoint-{global_step}"

--- a/src/cogkit/finetune/utils/checkpointing.py
+++ b/src/cogkit/finetune/utils/checkpointing.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from ..utils.file_utils import delete_files, find_files
+from ..utils.file_utils import delete_files, find_files, extract_ckpt_number
 
 
 def get_latest_ckpt_path_to_resume_from(
@@ -24,7 +24,7 @@ def get_latest_ckpt_path_to_resume_from(
             resume_from_checkpoint_path = None
         else:
             logger.info(f"Resuming from checkpoint {resume_from_checkpoint}")
-            global_step = int(resume_from_checkpoint_path.name.split("-")[1])
+            global_step = extract_ckpt_number(resume_from_checkpoint_path.name)
 
             initial_global_step = global_step
             first_epoch = global_step // num_update_steps_per_epoch

--- a/src/cogkit/finetune/utils/file_utils.py
+++ b/src/cogkit/finetune/utils/file_utils.py
@@ -1,6 +1,12 @@
 import os
+import re
 import shutil
 from pathlib import Path
+
+
+def extract_ckpt_number(name: str) -> int:
+    match = re.search(r"(\d+)$", name)
+    return int(match.group(1)) if match else -1
 
 
 def find_files(dir: str | Path, prefix: str = "checkpoint") -> list[str]:
@@ -10,7 +16,7 @@ def find_files(dir: str | Path, prefix: str = "checkpoint") -> list[str]:
         return []
     checkpoints = os.listdir(dir.as_posix())
     checkpoints = [c for c in checkpoints if c.startswith(prefix)]
-    checkpoints = sorted(checkpoints, key=lambda x: int(x.split("-")[1]))
+    checkpoints = sorted(checkpoints, key=extract_ckpt_number)
     checkpoints = [dir / c for c in checkpoints]
     return checkpoints
 


### PR DESCRIPTION
## Summary
- support new epoch checkpoint names
- allow validation only once when checkpointing per epoch
- default to no checkpointing steps by CLI
- tweak training script comments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch)*

------
https://chatgpt.com/codex/tasks/task_e_6866ade3d3f8832ba34406f09ee7b8fc